### PR TITLE
Add month view.

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -71,3 +71,91 @@
     }).flatten()
   )
 }
+
+// Make a month view of a calendar optionally with events
+#let calendar-month(
+    // Event list
+    event: (),
+    // Show (true) or hide (false) the title
+    show-title: true,
+    // Title above the month view --- if none and show-title is true display the range of dates
+    title: none,
+    // First day displayed in the month view
+    date-from: datetime.today(),
+    // Last day displayed in the month view
+    date-to: none,
+    ..args
+) = {
+    if date-to == none {
+        // If we have no date-to we show the rest of the month
+        for i in range(31) {
+            date-to = date-from + duration(days: i)
+            if date-to.month() != date-from.month() {
+                date-to = date-from + duration(days: i - 1)
+                break
+            }
+        }
+        // TODO(Discuss): Alternatively we could just display the next 31 days?
+        //date-to = date-from + duration(days: 31)
+    }
+    else {
+        // Check if date-from and date-to have been switched
+        if date-from > date-to {
+            let exchange = date-to
+            date-to = date-from
+            date-from = exchange
+        }
+    }
+    // Get all dates between date-from and date-to
+    let dates = ()
+    for i in range(calc.floor((date-to - date-from).days())+1) {
+        dates.push(date-from+duration(days: i))
+    }
+    // Get the weekdays of the dates
+    let nweek = dates.map(it => it.weekday()).filter(it => it == 1).len()
+    if date-from.weekday() > 1 {
+        nweek = nweek + 1
+    }
+    // Map the dates and weekdays
+    let week-day-map = ()
+    for (i, item) in dates.enumerate() {
+        if i == 0 or item.weekday() == 1 {
+            week-day-map.push(())
+        }
+        week-day-map.last().push(item)
+    }
+    stack(
+        dir: ttb,
+        grid(
+            columns: (1.5em,) * 7,
+            rows: (1.1em,) * (nweek + 1),
+            align: center + horizon,
+            ..args,
+            if show-title {
+                if title == none {
+                    grid.cell(colspan: 7)[#date-from.display() -- #date-to.display()]
+                }
+                else {
+                    grid.cell(colspan: 7)[#title]
+                }
+            },
+            [Mo], [Tu], [We], [Th], [Fr], [Sa], [Su],
+            ..week-day-map.map(week => {
+            (
+                range(1, week.first().weekday()).map(it => []),
+                week.map(day => {
+                    let day-str = day.display("[year]-[month]-[day]")
+                    if event.len()>0 and day-str in event.keys() {
+                        let params = event.at(day-str)
+                        let (shape, args) = params
+                        show: circle.with(..args)
+                        day.display("[day padding:none]")
+                    } else {
+                        day.display("[day padding:none]")
+                    }
+                })
+            ).join()
+            }).flatten()
+        )
+    )
+}


### PR DESCRIPTION
Regarding issue https://github.com/HPDell/typst-cineca/issues/1

I've taken your ([HPDell](https://github.com/HPDell)) demo code and adapted it a bit.

The following has been done/needs to be done:
- [X] Split the date-range into date-from and date-to
   - [X] Allows to only set the date-from (and see the rest of the month)
   - [X] If the date-from and date-to are not in the same month/year it still works
   - [X] Switch date-from and date-to if date-from is after date-to
- [ ] Decide if we want to show the rest of the month or some fixed number of days (31?) if there is no date-to (see TODO(Discuss) in the code
- [X] Add a title variable
   - [X] Which can be set and if it is not it will be "date-from -- date-to"
   - [X] Can be enabled or disabled (show-title)
- [X] Rename the weekday titles (two letters instead of one to make the days unique)
- [X] Event can be empty
- [X] Pass arguments to the grid
- [ ] Some regions prefer to have Sunday as the first day (Make this an option?)
- [ ] Add examples
- [ ] Do we want to add an argument (number-of-days) to display X days?
   - [ ] What if there is a date-from, date-to and a number-of-days?

```typst
#let calendar-month(
    event: (),
    show-title: true,
    title: none,
    date-from: datetime.today(),
    date-to: none,
    ..args
) = {
    if date-to == none {
        // If we have no date-to we show the rest of the month
        for i in range(31) {
            date-to = date-from + duration(days: i)
            if date-to.month() != date-from.month() {
                date-to = date-from + duration(days: i - 1)
                break
            }
        }
        // TODO(Discuss): Alternatively we could just display the next 31 days?
        //date-to = date-from + duration(days: 31)
    }
    else {
        // Check if date-from and date-to have been switched
        if date-from > date-to {
            let exchange = date-to
            date-to = date-from
            date-from = exchange
        }
    }
    // Get all dates between date-from and date-to
    let dates = ()
    for i in range(calc.floor((date-to - date-from).days())+1) {
        dates.push(date-from+duration(days: i))
    }
    // Get the weekdays of the dates
    let nweek = dates.map(it => it.weekday()).filter(it => it == 1).len()
    if date-from.weekday() > 1 {
        nweek = nweek + 1
    }
    // Map the dates and weekdays
    let week-day-map = ()
    for (i, item) in dates.enumerate() {
        if i == 0 or item.weekday() == 1 {
            week-day-map.push(())
        }
        week-day-map.last().push(item)
    }
    stack(
        dir: ttb,
        grid(
            columns: (1.5em,) * 7,
            rows: (1.1em,) * (nweek + 1),
            align: center + horizon,
            ..args,
            if show-title {
                if title == none {
                    grid.cell(colspan: 7)[#date-from.display() -- #date-to.display()]
                }
                else {
                    grid.cell(colspan: 7)[#title]
                }
            },
            [Mo], [Tu], [We], [Th], [Fr], [Sa], [Su],
            ..week-day-map.map(week => {
            (
                range(1, week.first().weekday()).map(it => []),
                week.map(day => {
                    let day-str = day.display("[year]-[month]-[day]")
                    if event.len()>0 and day-str in event.keys() {
                        let params = event.at(day-str)
                        let (shape, args) = params
                        show: circle.with(..args)
                        day.display("[day padding:none]")
                    } else {
                        day.display("[day padding:none]")
                    }
                })
            ).join()
            }).flatten()
        )
    )
}
```

Example with stroke, year/month overflow:
```typst
#calendar-month(
   date-from: datetime(year: 2024, month: 12, day: 24),
   date-to: datetime(year: 2025, month: 1, day: 24),
   stroke: 1pt,
)
```

Example with events:
```typst
#calendar-month(
  event: (
    "2024-05-21": (circle, (stroke: color.green, inset: 2pt)),
    "2024-05-22": (circle, (stroke: color.green, inset: 2pt)),
    "2024-05-27": (circle, (stroke: color.green, inset: 2pt)),
    "2024-05-28": (circle, (stroke: color.blue, inset: 2pt)),
    "2024-05-29": (circle, (stroke: color.blue, inset: 2pt)),
    "2024-06-03": (circle, (stroke: color.blue, inset: 2pt)),
    "2024-06-04": (circle, (stroke: color.yellow, inset: 2pt)),
    "2024-06-05": (circle, (stroke: color.yellow, inset: 2pt)),
    "2024-06-10": (circle, (stroke: color.red, inset: 2pt)),
  ),
  date-from: datetime(year: 2024, month: 5, day: 20),
  date-to: datetime(year: 2024, month: 6, day: 30),
)
```

What do you think about this?